### PR TITLE
feat: scaffold orchestration utilities

### DIFF
--- a/orchestrator/__init__.py
+++ b/orchestrator/__init__.py
@@ -4,5 +4,16 @@ __version__ = "0.1.0"
 
 # Import key components for easier access
 from .context.assembler import ContextAssembler, ContextBudget
+from .cli import OrchestratorCLI
+from .crdts import DomainSpecificCRDTs
+from .model_pool import ModelPoolManager
+from .governance import RealTimeGovernance
 
-__all__ = ["ContextAssembler", "ContextBudget"]
+__all__ = [
+    "ContextAssembler",
+    "ContextBudget",
+    "OrchestratorCLI",
+    "DomainSpecificCRDTs",
+    "ModelPoolManager",
+    "RealTimeGovernance",
+]

--- a/orchestrator/cli.py
+++ b/orchestrator/cli.py
@@ -1,0 +1,45 @@
+"""Command line interface for the LLM orchestrator."""
+from __future__ import annotations
+
+import sys
+from typing import List, Any
+
+
+class OrchestratorCLI:
+    """Terminal interface with predictable contracts."""
+
+    def __init__(self, orchestrator: Any) -> None:
+        """Create a new CLI wrapper.
+
+        Args:
+            orchestrator: The underlying orchestrator instance.
+        """
+        self.orchestrator = orchestrator
+        self.is_tty = sys.stdout.isatty()
+
+    def execute(self, args: List[str]) -> int:
+        """Single entry point with semantic exit codes."""
+        if self.is_tty:
+            return self._run_tui()
+        return self._run_pipeline()
+
+    def replay(self, execution_id: str) -> int:
+        """Bit-perfect replay from event log."""
+        events = self.orchestrator.event_log.get_events(execution_id)
+        return self._replay_deterministic(events)
+
+    # Internal helpers -----------------------------------------------------
+    def _run_tui(self) -> int:
+        """Interactive TUI mode placeholder."""
+        # Real implementation would start an interactive interface
+        return 0
+
+    def _run_pipeline(self) -> int:
+        """Pipeline mode producing JSON lines."""
+        # Real implementation would parse ``args`` and emit JSON
+        return 0
+
+    def _replay_deterministic(self, events: List[Any]) -> int:
+        """Deterministically replay a list of events."""
+        # Real implementation would re-create state from events
+        return 0

--- a/orchestrator/crdts.py
+++ b/orchestrator/crdts.py
@@ -1,0 +1,55 @@
+"""Domain specific CRDT implementations."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, List
+
+
+@dataclass
+class ReducibleMap:
+    """Minimal map that can be reduced using a merge function."""
+    merge_fn: Callable[[List[Any], List[Any]], List[Any]]
+    identity: List[Any]
+
+    def merge(self, a: List[Any], b: List[Any]) -> List[Any]:
+        return self.merge_fn(a, b)
+
+
+@dataclass
+class AssociativeCounter:
+    """Commutative aggregation of numerical scores."""
+    combine_fn: Callable[[List[float]], Dict[str, float]]
+
+    def combine(self, scores: List[float]) -> Dict[str, float]:
+        return self.combine_fn(scores)
+
+
+class DomainSpecificCRDTs:
+    """CRDTs tailored to orchestration patterns."""
+
+    def top_k_list(self, k: int) -> ReducibleMap:
+        """Mergeable top-k results across agents."""
+        return ReducibleMap(
+            merge_fn=lambda a, b: sorted(a + b, key=lambda x: x.score)[:k],
+            identity=[],
+        )
+
+    def score_aggregator(self) -> AssociativeCounter:
+        """Commutative score aggregation."""
+        return AssociativeCounter(
+            combine_fn=lambda scores: {
+                "min": min(scores) if scores else 0.0,
+                "max": max(scores) if scores else 0.0,
+                "mean": sum(scores) / len(scores) if scores else 0.0,
+                "consensus": self._weighted_consensus(scores),
+            }
+        )
+
+    def _weighted_consensus(self, scores: List[float]) -> float:
+        """Simple weighted consensus calculation.
+
+        Currently uses the arithmetic mean as a placeholder.
+        """
+        if not scores:
+            return 0.0
+        return sum(scores) / len(scores)

--- a/orchestrator/governance.py
+++ b/orchestrator/governance.py
@@ -1,0 +1,61 @@
+"""Real-time governance through telemetry feedback."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict
+
+
+class TelemetryCollector:
+    """Collects telemetry metrics."""
+
+    def get_metrics_summary(self, metric: str, window: int) -> Dict[str, float]:
+        return {"p95": 0.0}
+
+
+@dataclass
+class PIDController:
+    """Very small PID controller placeholder."""
+    adjust_fn: Callable[[float, Callable[[], None]], None] | None = None
+
+    def adjust(self, error: float, action: Callable[[], None]) -> None:
+        if self.adjust_fn:
+            self.adjust_fn(error, action)
+        else:
+            action()
+
+
+class IsolationForest:
+    """Placeholder anomaly detector."""
+
+    def detect(self, metrics: Dict[str, float]) -> bool:
+        return False
+
+
+class RealTimeGovernance:
+    """Governance through continuous telemetry feedback."""
+
+    def __init__(self, telemetry: TelemetryCollector) -> None:
+        self.telemetry = telemetry
+        self.control_loop = PIDController()
+        self.anomaly_detector = IsolationForest()
+        self.target_cost = 0.0
+
+    def adjust_policy_by_telemetry(self) -> None:
+        """Dynamic policy adjustment based on real metrics."""
+        metrics = self.telemetry.get_metrics_summary("cost_per_token", 300)
+        if metrics.get("p95", 0.0) > self.target_cost * 1.2:
+            self.control_loop.adjust(
+                error=metrics["p95"] - self.target_cost,
+                action=self._downgrade_default_tier,
+            )
+
+        if self.anomaly_detector.detect(metrics):
+            self._trigger_circuit_breaker()
+
+    def _downgrade_default_tier(self) -> None:
+        """Placeholder for tier downgrade logic."""
+        pass
+
+    def _trigger_circuit_breaker(self) -> None:
+        """Placeholder for circuit breaker activation."""
+        pass

--- a/orchestrator/model_pool.py
+++ b/orchestrator/model_pool.py
@@ -1,0 +1,51 @@
+"""Predictive model pool management."""
+from __future__ import annotations
+
+import asyncio
+import math
+from collections import defaultdict
+from typing import Dict, List
+
+
+class TimeSeriesPredictor:
+    """Very small placeholder predictor."""
+
+    def predict_demand(self, horizon_minutes: int, confidence_level: float) -> Dict[str, float]:
+        # In a real system this would analyze historical telemetry.
+        return {}
+
+
+class ModelPoolManager:
+    """Manage model pools based on predicted demand."""
+
+    def __init__(self) -> None:
+        self.pools: Dict[str, List[object]] = defaultdict(list)
+        self.usage_patterns = TimeSeriesPredictor()
+
+    async def preheat_by_prediction(self) -> None:
+        """Preheat models based on usage pattern predictions."""
+        predictions = self.usage_patterns.predict_demand(
+            horizon_minutes=60, confidence_level=0.95
+        )
+        for model_tier, expected_qps in predictions.items():
+            target_size = self._calculate_pool_size(expected_qps, p99_latency_target=100)
+            await self._resize_pool(model_tier, target_size)
+
+    def _calculate_pool_size(self, qps: float, p99_latency_target: float) -> int:
+        """Little's Law: L = λW"""
+        avg_processing_time = self._get_p50_processing_time()
+        return math.ceil(qps * avg_processing_time * 1.5)
+
+    async def _resize_pool(self, model_tier: str, target_size: int) -> None:
+        """Resize the model pool to match the target size."""
+        current_size = len(self.pools[model_tier])
+        if target_size > current_size:
+            self.pools[model_tier].extend([object() for _ in range(target_size - current_size)])
+        else:
+            del self.pools[model_tier][target_size:]
+        await asyncio.sleep(0)  # yield control
+
+    def _get_p50_processing_time(self) -> float:
+        """Return the median processing time for a request in seconds."""
+        # Placeholder value of 50ms
+        return 0.05


### PR DESCRIPTION
## Summary
- add terminal-oriented `OrchestratorCLI`
- introduce domain CRDT helpers for merge semantics
- prototype model pool manager and real-time governance components

## Testing
- `pytest` *(fails: SyntaxError in tests/test_repl.py and other collection issues)*

------
https://chatgpt.com/codex/tasks/task_b_68b9cc11f3d4832faa70702f1429d2f8