### PR TITLE
docs: add architecture overview with mermaid diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LLM Orchestrator
 
-A high-performance orchestration framework for managing multi-agent LLM workflows with fine-grained control over context, tooling, and resource allocation.
+A high-performance orchestration framework for managing multi-agent LLM workflows with fine‑grained control over context, tooling, and resource allocation.
 
 ## Features
 
@@ -10,6 +10,21 @@ A high-performance orchestration framework for managing multi-agent LLM workflow
 - **Sandboxed Execution**: Secure, isolated execution environments
 - **Structured Artifacts**: Type-safe data passing between components
 - **REPL Interface**: Interactive debugging and control
+
+## Architecture
+
+```mermaid
+graph TD
+    A[Client] --> B[CLI / REPL]
+    B --> C[Orchestrator Core]
+    C --> D[Context Assembler]
+    C --> E[Tooling & Sandbox]
+    C --> F[Artifact Storage]
+    C --> G[Event Log]
+    C --> H[Security & Governance]
+```
+
+See [Architecture Overview](docs/architecture_overview.md) for a detailed component guide.
 
 ## Roadmap: Hardening the Orchestrator
 

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -1,0 +1,18 @@
+# Architecture Overview
+
+LLM Orchestrator is organized into modular subsystems that collaborate to run multi‑agent workflows.
+
+## Core Components
+
+- **Context Assembler** (`orchestrator/context/assembler.py`): builds prompt context with token budgeting, deduplication and summarization.
+- **Sharded Event Log** (`orchestrator/event_log.py`): append‑only log with cryptographic hash chains, optional PII redaction, signing and Merkle anchoring.
+- **Artifact Storage** (`orchestrator/artifacts`): content‑addressable store for JSON, text, binary and other artifacts with rich metadata.
+- **Sandbox** (`orchestrator/sandbox`): isolated execution environment for tools and confidential workloads.
+- **Security Modules** (`orchestrator/security`): primitives for HSM signing, rate limiting, differential privacy, secure deletion and more.
+- **Real‑Time Governance** (`orchestrator/governance.py`): telemetry‑driven policy adjustment via PID control and anomaly detection.
+- **Model Pool Manager** (`orchestrator/model_pool.py`): predictive scaling of model instances using time‑series forecasts.
+
+## Extensibility
+
+The orchestrator exposes a type‑safe artifact API and a versioned tool registry, enabling teams to integrate custom models, tools and governance policies while preserving reproducibility.
+


### PR DESCRIPTION
## Summary
- add architecture diagram to README using Mermaid
- document core subsystems in new architecture overview page

## Testing
- `pytest tests/ -v` *(fails: ModuleNotFoundError: No module named 'jsonschema'; ModuleNotFoundError: No module named 'psutil'; IndentationError in tests/test_tool_worker.py; SyntaxError in tests/test_workers.py)*

------
https://chatgpt.com/codex/tasks/task_b_68b9e32bea18832f8b5b06a5951d680d