### PR TITLE
feat: add recursion-safe tool normalization

### DIFF
--- a/examples/demo_tool_normalization.py
+++ b/examples/demo_tool_normalization.py
@@ -1,0 +1,41 @@
+"""
+Demonstration of recursion-safe tool normalization via ToolProxy.
+Run this to confirm ToolResult shape and scalar boxing.
+"""
+
+from orchestrator import tools
+from orchestrator.tools.normalization import patch_registry
+
+
+def main():
+    patch_registry(tools.tool_registry)
+
+    class Calculator:
+        name = "calculator"
+        version = "1.0.0"
+
+        def implementation(self, payload: dict):
+            op = payload.get("operation")
+            a, b = payload.get("a", 0), payload.get("b", 0)
+            if op == "add":
+                return a + b
+            if op == "mul":
+                return a * b
+            return {"success": True, "data": 7, "metadata": {"note": "default"}}
+
+    internal = getattr(tools.tool_registry, "_tools", {})
+    internal.setdefault("calculator", {})["1.0.0"] = Calculator()
+
+    calc = tools.tool_registry.get_tool("calculator", "1.0.0")
+    r1 = calc.implementation({"operation": "add", "a": 5, "b": 7})
+    r2 = calc.implementation({"operation": "mul", "a": 3, "b": 9})
+    r3 = calc.implementation({"operation": "noop"})
+
+    print("add ->", r1)
+    print("mul ->", r2)
+    print("noop->", r3)
+    print("boxed access ok:", r1.data["data"], r2.data["value"])
+
+
+if __name__ == "__main__":
+    main()

--- a/orchestrator/tools/__init__.py
+++ b/orchestrator/tools/__init__.py
@@ -182,6 +182,13 @@ class ToolResult(BaseModel):
 # Global registry instance
 tool_registry = ToolRegistry()
 
+from .normalization import patch_registry  # noqa: E402
+
+try:
+    patch_registry(tool_registry)
+except Exception as _e:  # pragma: no cover - defensive
+    pass
+
 def register_tool(version: str, **kwargs):
     """Decorator to register a tool function."""
     def decorator(func):

--- a/orchestrator/tools/normalization.py
+++ b/orchestrator/tools/normalization.py
@@ -1,0 +1,159 @@
+"""
+Recursion-safe tool normalization via Proxy.
+
+This module wraps tools at retrieval time so every call to `.implementation(payload)`
+returns a proper ToolResult; raw scalars are boxed into a dict for subscript safety.
+No monkey-patching of ToolVersion or individual tools is required.
+"""
+
+from __future__ import annotations
+from typing import Any, Optional, Callable
+import inspect
+
+try:
+    # Import from sibling package; orchestrator/tools/__init__.py exports ToolResult
+    from . import ToolResult  # type: ignore
+except Exception as e:
+    # Fallback shim if importing standalone in examples/tests
+    class ToolResult:  # type: ignore
+        def __init__(self, success: bool, data: Any = None, metadata: Optional[dict] = None):
+            self.success = bool(success)
+            self.data = data
+            self.metadata = metadata or {}
+        def __repr__(self) -> str:
+            return f"ToolResult(success={self.success}, data={self.data!r}, metadata={self.metadata!r})"
+
+
+def _box_scalar(v: Any) -> Any:
+    """If v is a number/bool, box into a dict so later subscripting is safe."""
+    if isinstance(v, (int, float, bool)):
+        return {"data": v, "value": v}
+    return v
+
+
+def _to_toolresult(x: Any) -> ToolResult:
+    """Normalize anything to a ToolResult; keep success/metadata if present; box scalars."""
+    if isinstance(x, ToolResult):
+        return ToolResult(
+            success=getattr(x, "success", True),
+            data=_box_scalar(getattr(x, "data", None)),
+            metadata=getattr(x, "metadata", {}) or {},
+        )
+    if isinstance(x, dict) and "data" in x:
+        return ToolResult(
+            success=bool(x.get("success", True)),
+            data=_box_scalar(x.get("data")),
+            metadata=x.get("metadata", {}) or {},
+        )
+    return ToolResult(success=True, data=_box_scalar(x), metadata={"wrapped": True})
+
+
+class ToolProxy:
+    """
+    Thin, recursion-safe wrapper around a tool instance.
+    Only intercepts implementation(payload) to normalize outputs; everything else delegates.
+    """
+
+    __slots__ = ("_inner", "_proxied")
+
+    def __init__(self, inner: Any):
+        self._inner = inner
+        self._proxied = True  # marker for idempotence
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._inner, name)
+
+    @property
+    def name(self) -> str:
+        return getattr(self._inner, "name", self._inner.__class__.__name__)
+
+    @property
+    def version(self) -> str:
+        return getattr(self._inner, "version", "*")
+
+    def implementation(self, payload: dict) -> ToolResult:
+        out = self._inner.implementation(payload)
+        return _to_toolresult(out)
+
+    # Many tool classes also expose execute(); keep it transparent.
+    def execute(self, payload: dict) -> Any:
+        return getattr(self._inner, "execute")(payload)
+
+
+def _ensure_instance(obj: Any) -> Any:
+    """Instantiate classes; leave instances alone."""
+    return obj() if inspect.isclass(obj) else obj
+
+
+def _ensure_proxied(obj: Any) -> Any:
+    """Wrap instances in ToolProxy exactly once."""
+    if getattr(obj, "_proxied", False):
+        return obj
+    return ToolProxy(obj)
+
+
+def _normalize_map(internal: Any) -> None:
+    """Convert classes→instances and wrap in proxies in the registry's internal map."""
+    if not isinstance(internal, dict):
+        return
+    for name, versions in list(internal.items()):
+        if not isinstance(versions, dict):
+            continue
+        for ver, obj in list(versions.items()):
+            obj = _ensure_instance(obj)
+            obj = _ensure_proxied(obj)
+            versions[ver] = obj
+
+
+def patch_registry(registry: Any) -> None:
+    """
+    Apply normalization to a ToolRegistry-like object.
+    Patches get_tool to return proxied instances and normalizes existing/loaded/registered tools.
+    Idempotent: only patches once per registry.
+    """
+    if getattr(registry, "_normalization_patched", False):
+        return
+
+    # 1) Patch get_tool via the *class* method to avoid recursion
+    orig_cls_get_tool: Callable = registry.__class__.get_tool  # type: ignore[attr-defined]
+    registry.get_tool = orig_cls_get_tool.__get__(registry, registry.__class__)  # rebind original
+
+    def _safe_get_tool(self, name: str, version_spec: str) -> Any:
+        obj = orig_cls_get_tool(self, name, version_spec)
+        obj = _ensure_instance(obj)
+        obj = _ensure_proxied(obj)
+        internal = getattr(self, "_tools", None)
+        if isinstance(internal, dict):
+            internal.setdefault(name, {})[version_spec] = obj
+        return obj
+
+    registry.get_tool = _safe_get_tool.__get__(registry, registry.__class__)  # type: ignore
+
+    # 2) Patch register to normalize future registrations without touching originals
+    if hasattr(registry, "register"):
+        _orig_reg = registry.register
+
+        def _safe_register(tool_obj: Any) -> Any:
+            tool_obj = _ensure_instance(tool_obj)
+            tool_obj = _ensure_proxied(tool_obj)
+            return _orig_reg(tool_obj)
+
+        registry.register = _safe_register  # type: ignore[assignment]
+
+    # 3) Patch load_from_directory to normalize after loading from disk
+    if hasattr(registry, "load_from_directory"):
+        _orig_loader = registry.load_from_directory
+
+        def _safe_loader(path: str) -> None:
+            _orig_loader(path)
+            internal = getattr(registry, "_tools", {})
+            _normalize_map(internal)
+
+        registry.load_from_directory = _safe_loader  # type: ignore[assignment]
+
+    # 4) Normalize current registry contents
+    internal = getattr(registry, "_tools", {})
+    _normalize_map(internal)
+
+    # Done
+    registry._normalization_patched = True

--- a/tests/test_tool_normalization.py
+++ b/tests/test_tool_normalization.py
@@ -1,0 +1,70 @@
+import pytest
+from orchestrator import tools
+from orchestrator.tools import ToolResult
+from orchestrator.tools.normalization import patch_registry
+
+
+class DummyCalc:
+    name = "calculator"
+    version = "1.0.0"
+
+    def implementation(self, payload: dict):
+        op = payload.get("operation")
+        a, b = payload.get("a", 0), payload.get("b", 0)
+        if op == "add":
+            return a + b
+        if op == "sub":
+            return a - b
+        return {"success": True, "data": 42, "metadata": {"op": op}}
+
+
+def test_proxy_patch_is_idempotent():
+    reg = getattr(tools, "tool_registry")
+    patch_registry(reg)
+    patch_registry(reg)  # no-op
+    assert getattr(reg, "_normalization_patched", False) is True
+
+
+def test_scalar_results_are_boxed_and_toolresult():
+    reg = tools.tool_registry
+    internal = getattr(reg, "_tools", {})
+    internal.setdefault("calculator", {})["1.0.0"] = DummyCalc()
+    patch_registry(reg)
+
+    calc = reg.get_tool("calculator", "1.0.0")
+    out = calc.implementation({"operation": "add", "a": 3, "b": 9})
+    assert isinstance(out, ToolResult)
+    assert out.success is True
+    assert isinstance(out.data, dict)
+    assert out.data["data"] == 12
+    assert out.data["value"] == 12
+
+
+def test_dict_shaped_results_pass_through_and_box_inner():
+    reg = tools.tool_registry
+    internal = getattr(reg, "_tools", {})
+    internal.setdefault("calculator", {})["1.0.0"] = DummyCalc()
+    patch_registry(reg)
+
+    calc = reg.get_tool("calculator", "1.0.0")
+    out = calc.implementation({"operation": "noop"})
+    assert isinstance(out, ToolResult)
+    assert out.success is True
+    assert out.metadata.get("op") == "noop"
+    assert isinstance(out.data, dict)
+    assert out.data["data"] == 42
+    assert out.data["value"] == 42
+
+
+def test_register_and_load_are_safe_to_call(monkeypatch, tmp_path):
+    reg = tools.tool_registry
+    patch_registry(reg)
+
+    tool = DummyCalc()
+    if hasattr(reg, "register"):
+        reg.register(tool)
+    got = reg.get_tool("calculator", "1.0.0")
+    assert hasattr(got, "_proxied") and got._proxied is True
+
+    if hasattr(reg, "load_from_directory"):
+        reg.load_from_directory(str(tmp_path))


### PR DESCRIPTION
## Summary
- add ToolProxy-based normalization to wrap tools and standardize ToolResult outputs
- auto-patch tool registry on import for consistent behavior
- cover normalization with dedicated tests and demo

## Testing
- `pytest -q` *(fails: SyntaxError in orchestrator.sandbox and some tests)*
- `pytest tests/test_tool_normalization.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68bbec2a7924832fa2e4512f304f1cb5